### PR TITLE
Set kernel.core_pattern and ulimit

### DIFF
--- a/base-images/aws/base-image.pkr.hcl
+++ b/base-images/aws/base-image.pkr.hcl
@@ -69,6 +69,7 @@ build {
       "${path.root}/../scripts/update.sh",
       "${path.root}/../scripts/tools.sh",
       "${path.root}/../scripts/datadog.sh",
+      "${path.root}/../scripts/coredumps.sh",
       "${path.root}/../scripts/fail2ban.sh",
       "${path.root}/../scripts/aws-extras.sh"
     ]

--- a/base-images/scripts/coredumps.sh
+++ b/base-images/scripts/coredumps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+# directory for core dumps
+mkdir -p /var/crash
+
+# tell the kernel to put them in that directory
+sysctl -w kernel.core_pattern=/var/crash/coredump-%e.%p.%h.%t
+
+# remove the limit on core dump size
+ulimit -c unlimited


### PR DESCRIPTION
We have to set these at the image level since they are kernel parameters
that Docker inherits and has no control over
